### PR TITLE
Update META.in to contain new needed packages

### DIFF
--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Transport layer security (TLS 1.x) purely in OCaml"
-requires = "cstruct sexplib result hkdf nocrypto x509 logs fmt PPX_SEXP_CONV_RUNTIME"
+requires = "cstruct sexplib result hkdf fiat_p256 hacl_x25519 nocrypto x509 logs fmt PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "tls.cma"
 plugin(byte) = "tls.cma"
 archive(native) = "tls.cmxa"


### PR DESCRIPTION
Building a unikernel with this branch reported missing implementations for the EC ciphers modules.